### PR TITLE
Bug fix to load referenced assemblies in the same folder

### DIFF
--- a/Docpal/Program.cs
+++ b/Docpal/Program.cs
@@ -33,7 +33,7 @@ namespace Docpal
 			{
 				Console.WriteLine("Building docs...");
 
-				var dll = Assembly.LoadFile(dllPath);
+				var dll = Assembly.LoadFrom(dllPath);
 				DocpalGenerator docpal;
 				var xmlData = new XmlDocument();
 


### PR DESCRIPTION
This is a bug fix that allows referenced DLLs in the same folder as the original DLL to be loaded when generating documentation.  

This fixes issue #2 