### PR TITLE
avoid to crash if assemblies with no namespace

### DIFF
--- a/Docpal/DocUtilities.cs
+++ b/Docpal/DocUtilities.cs
@@ -565,7 +565,7 @@ namespace Docpal
             // e.g. Dictionary<string, int>
             else if (bareType.IsGenericType)
             {
-                if (includeNamespace)
+                if (includeNamespace && !string.IsNullOrEmpty(bareType.Namespace))
                 {
                     sb.Append($"{bareType.Namespace}.");
                 }
@@ -588,7 +588,7 @@ namespace Docpal
             // e.g. System.String
             else
             {
-                if (includeNamespace) sb.Append($"{bareType.Namespace}.");
+                if (includeNamespace && !string.IsNullOrEmpty(bareType.Namespace)) sb.Append($"{bareType.Namespace}.");
                 sb.Append(bareName);
             }
 

--- a/Docpal/DocpalPages.cs
+++ b/Docpal/DocpalPages.cs
@@ -30,113 +30,115 @@ using System.Threading.Tasks;
 
 namespace Docpal
 {
-	class DocpalPages : DocpalGenerator
-	{
-		public DocpalPages(ProjectXmlDocs docs, Assembly asm) : base(docs, asm)
-		{
-		}
+    class DocpalPages : DocpalGenerator
+    {
+        public DocpalPages(ProjectXmlDocs docs, Assembly asm) : base(docs, asm)
+        {
+        }
 
-		public override void BuildDocs(string outputPath)
-		{
-			var pages = new PageTree("docs");
-			var PageTrees = new List<PageTree>();
+        public override void BuildDocs(string outputPath)
+        {
+            var pages = new PageTree("docs");
+            var PageTrees = new List<PageTree>();
 
-			foreach (var type in Library.GetExportedTypes())
-			{
-				var typePath = $"{type.Namespace.Replace('.', '/')}/{DocUtilities.GetURLTitle(type)}";
-				var typeData = Docs[ID.GetIDString(type)];
+            foreach (var type in Library.GetExportedTypes())
+            {
+                var typePath = $"{DocUtilities.GetURLTitle(type)}";
+                if (type.Namespace != null)
+                    typePath = $"{type.Namespace.Replace('.', '/')}/{typePath}";
+                var typeData = Docs[ID.GetIDString(type)];
 
-				pages[typePath] = new TypePage(type, typeData, Docs);
-				PageTrees.Add(pages.GetNode(typePath));
+                pages[typePath] = new TypePage(type, typeData, Docs);
+                PageTrees.Add(pages.GetNode(typePath));
 
-				// Constructors
-				var ctors = type.GetConstructors();
-				if (ctors.Length > 0)
-				{
+                // Constructors
+                var ctors = type.GetConstructors();
+                if (ctors.Length > 0)
+                {
                     // Path to ctors group
-					var ctorsGroupPath = $"{typePath}/ctors";
+                    var ctorsGroupPath = $"{typePath}/ctors";
 
                     var ctorsData = new Dictionary<ConstructorInfo, MemberXmlDocs>();
                     foreach (var ctor in ctors)
                     {
                         var ctorData = Docs[ID.GetIDString(ctor)];
                         ctorsData.Add(ctor, ctorData);
-                    } 
+                    }
 
-					pages[ctorsGroupPath] = new ConstructorsPage(type, ctors, ctorsData);
-					PageTrees.Add(pages.GetNode(ctorsGroupPath));                    
-				}
+                    pages[ctorsGroupPath] = new ConstructorsPage(type, ctors, ctorsData);
+                    PageTrees.Add(pages.GetNode(ctorsGroupPath));
+                }
 
-				// Method groups
-				foreach (var methodGroup in type.GetMethods()
-					.Where(m => !m.Name.StartsWith("get_") && !m.Name.StartsWith("set_"))
-					.GroupBy(m => m.Name))
-				{
-					// Path to method group
-					var methodGroupPath = $"{typePath}/{methodGroup.Key}";
+                // Method groups
+                foreach (var methodGroup in type.GetMethods()
+                    .Where(m => !m.Name.StartsWith("get_") && !m.Name.StartsWith("set_"))
+                    .GroupBy(m => m.Name))
+                {
+                    // Path to method group
+                    var methodGroupPath = $"{typePath}/{methodGroup.Key}";
 
-					// Map of reflected methods and documentation
-					var methods = new Dictionary<MethodInfo, MemberXmlDocs>();
+                    // Map of reflected methods and documentation
+                    var methods = new Dictionary<MethodInfo, MemberXmlDocs>();
 
-					foreach (var method in methodGroup)
-					{
-						var methodData = Docs[ID.GetIDString(method)];
-						methods[method] = methodData;
-					}
+                    foreach (var method in methodGroup)
+                    {
+                        var methodData = Docs[ID.GetIDString(method)];
+                        methods[method] = methodData;
+                    }
 
-					pages[methodGroupPath] = new MethodGroupPage(type, methodGroup.Key, methods);
-					PageTrees.Add(pages.GetNode(methodGroupPath));
-				}
+                    pages[methodGroupPath] = new MethodGroupPage(type, methodGroup.Key, methods);
+                    PageTrees.Add(pages.GetNode(methodGroupPath));
+                }
 
-				// Fields
-				foreach (var field in type.GetFields().Where(f => (f.IsPublic || !f.IsPrivate) && (!f.DeclaringType.IsEnum || !f.IsSpecialName)))
-				{
-					var fieldPath = Path.Combine(typePath, field.Name).Replace('\\', '/');
-					var fieldData = Docs[ID.GetIDString(field)];
-					pages[fieldPath] = new FieldPage(field, fieldData);
-					PageTrees.Add(pages.GetNode(fieldPath));
-				}
+                // Fields
+                foreach (var field in type.GetFields().Where(f => (f.IsPublic || !f.IsPrivate) && (!f.DeclaringType.IsEnum || !f.IsSpecialName)))
+                {
+                    var fieldPath = Path.Combine(typePath, field.Name).Replace('\\', '/');
+                    var fieldData = Docs[ID.GetIDString(field)];
+                    pages[fieldPath] = new FieldPage(field, fieldData);
+                    PageTrees.Add(pages.GetNode(fieldPath));
+                }
 
-				// Properties and Indexers
-				int numIndexers = 0;
-				foreach (var property in type.GetProperties())
-				{
-					var propData = Docs[ID.GetIDString(property)];
+                // Properties and Indexers
+                int numIndexers = 0;
+                foreach (var property in type.GetProperties())
+                {
+                    var propData = Docs[ID.GetIDString(property)];
 
-					string propPath;
-					if (property.GetIndexParameters().Length > 0)
-					{
-						propPath = $"{typePath}/this/{++numIndexers}";
-					}
-					else
-					{
-						propPath = $"{typePath}/{property.Name}";
-					}
+                    string propPath;
+                    if (property.GetIndexParameters().Length > 0)
+                    {
+                        propPath = $"{typePath}/this/{++numIndexers}";
+                    }
+                    else
+                    {
+                        propPath = $"{typePath}/{property.Name}";
+                    }
 
-					pages[propPath] = new PropertyPage(property, propData);
-					PageTrees.Add(pages.GetNode(propPath));
-				}
-			}
+                    pages[propPath] = new PropertyPage(property, propData);
+                    PageTrees.Add(pages.GetNode(propPath));
+                }
+            }
 
-			// Create a task for each document that needs to be exported, run them all at once
-			var exportTasks = new Task[PageTrees.Count];
-			for (int i = 0; i < PageTrees.Count; i++)
-			{
-				var node = PageTrees[i];
-				exportTasks[i] = Task.Run(() =>
-				{
-					var documentDir = Directory.GetParent($"{outputPath}/{node.Path}").FullName;
-					var documentPath = $"{outputPath}/{node.Path}.md";
-					Directory.CreateDirectory(documentDir);
-					using (var writer = new MarkdownWriter(documentPath))
-					{
-						node.Page.Render(node, writer);
-					}
-				});
-			}
+            // Create a task for each document that needs to be exported, run them all at once
+            var exportTasks = new Task[PageTrees.Count];
+            for (int i = 0; i < PageTrees.Count; i++)
+            {
+                var node = PageTrees[i];
+                exportTasks[i] = Task.Run(() =>
+                {
+                    var documentDir = Directory.GetParent($"{outputPath}/{node.Path}").FullName;
+                    var documentPath = $"{outputPath}/{node.Path}.md";
+                    Directory.CreateDirectory(documentDir);
+                    using (var writer = new MarkdownWriter(documentPath))
+                    {
+                        node.Page.Render(node, writer);
+                    }
+                });
+            }
 
-			// Wait for all export tasks to finish
-			Task.WaitAll(exportTasks);
-		}
-	}
+            // Wait for all export tasks to finish
+            Task.WaitAll(exportTasks);
+        }
+    }
 }


### PR DESCRIPTION
avoid crash if some assemblies with no namespace referenced, for me happened with a cs wrapper for com automation, the `wrapper.cs` was like the following

```csharp
public static class MyClass
{

    public static void Method(int a, int b)
    {
    }

}
```