### PR TITLE
arguments documentation ; mspace option

### DIFF
--- a/Docpal/Args.cs
+++ b/Docpal/Args.cs
@@ -41,7 +41,8 @@ namespace Docpal
         public static readonly bool Help;
 
         public static readonly bool MethodGroupsTable;
-        public static readonly bool PropertiesTable;
+        public static readonly bool MethodGroupsSpacing;
+        public static readonly bool PropertiesTable;        
 
         static Args()
         {
@@ -74,6 +75,7 @@ namespace Docpal
                 {
                     var flag = args[i].TrimStart('-');
                     if (flag == "mgtable") MethodGroupsTable = true;
+                    else if (flag == "mgspace") MethodGroupsSpacing = true;
                     else if (flag == "proptable") PropertiesTable = true;
                     Flags.Add(flag);
                 }

--- a/Docpal/Pages/ConstructorsPage.cs
+++ b/Docpal/Pages/ConstructorsPage.cs
@@ -47,7 +47,7 @@ namespace Docpal.Pages
             writer.WriteHeader(1, Title);
             foreach (var (ctor, idx) in _ctors.Select((ctor, idx) => (ctor, idx)))
             {
-                if (idx > 0)
+                if (Args.MethodGroupsSpacing && idx > 0)
                 {
                     writer.WriteLine();                    
                     writer.WriteLine("<p>&nbsp;</p>");

--- a/Docpal/Pages/MethodGroupPage.cs
+++ b/Docpal/Pages/MethodGroupPage.cs
@@ -28,54 +28,65 @@ using System.Reflection;
 
 namespace Docpal.Pages
 {
-	public class MethodGroupPage : Page
-	{
-		private readonly Type _type;
-		private readonly Dictionary<MethodInfo, MemberXmlDocs> _methodData;
+    public class MethodGroupPage : Page
+    {
+        private readonly Type _type;
+        private readonly Dictionary<MethodInfo, MemberXmlDocs> _methodData;
 
-		public MethodGroupPage(Type type, string name, Dictionary<MethodInfo, MemberXmlDocs> methodData) : base(null)
-		{
-			_type = type;
-			_methodData = methodData;
-			Title = $"{DocUtilities.GetDisplayTitle(type)}.{DocUtilities.GetIdentifier(name)} method";
-		}
+        public MethodGroupPage(Type type, string name, Dictionary<MethodInfo, MemberXmlDocs> methodData) : base(null)
+        {
+            _type = type;
+            _methodData = methodData;
+            Title = $"{DocUtilities.GetDisplayTitle(type)}.{DocUtilities.GetIdentifier(name)} method";
+        }
 
-		public override void Render(PageTree parent, MarkdownWriter writer)
-		{
-			writer.WriteHeader(1, Title);
-			foreach (var data in _methodData.OrderBy(m => m.Key.GetParameters().Length))
-			{
-				var method = data.Key;
-				var docs = data.Value;
+        public override void Render(PageTree parent, MarkdownWriter writer)
+        {
+            writer.WriteHeader(1, Title);
+            foreach (var (data, idx) in _methodData                
+                .OrderBy(m => m.Key.GetParameters().Length)
+                .Select((data, idx) => (data, idx)))
+            {
+                var method = data.Key;
+                var docs = data.Value;
 
-				writer.WriteHeader(2, DocUtilities.GetMethodSignature(method, false, false));
-				writer.WriteParagraph(docs?.Summary);
-				writer.WriteHeader(3, "Signature");
-				writer.WriteCodeBlock("csharp", DocUtilities.GetMethodSignature(method, true, true));
+                if (Args.MethodGroupsSpacing && idx > 0)
+                {
+                    writer.WriteLine();
+                    writer.WriteLine("<p>&nbsp;</p>");
+                    writer.WriteLine("<p>&nbsp;</p>");
+                    writer.WriteLine("<hr/>");
+                    writer.WriteLine();
+                }
 
-				if (docs != null)
-				{
-					if (docs.HasTypeParameters)
-					{
-						writer.WriteHeader(3, "Type Parameters");
-						foreach (var tp in method.GetGenericArguments())
-						{
-							var desc = docs?.GetTypeParameterDescription(tp.Name) ?? "_(No Description)_";
-							writer.WriteLine($"- `{tp.Name}`: {desc}");
-						}
-						writer.WriteLine();
-					}
+                writer.WriteHeader(2, DocUtilities.GetMethodSignature(method, false, false));
+                writer.WriteParagraph(docs?.Summary);
+                writer.WriteHeader(3, "Signature");
+                writer.WriteCodeBlock("csharp", DocUtilities.GetMethodSignature(method, true, true));
 
-					if (docs.HasParameters)
-					{
-						writer.WriteHeader(3, "Parameters");
-						foreach (var p in method.GetParameters())
-						{
-							var desc = docs?.GetParameterDescription(p.Name) ?? "_(No Description)_";
-							writer.WriteLine($"- `{p.Name}`: {desc}");
-						}
-						writer.WriteLine();
-					}
+                if (docs != null)
+                {
+                    if (docs.HasTypeParameters)
+                    {
+                        writer.WriteHeader(3, "Type Parameters");
+                        foreach (var tp in method.GetGenericArguments())
+                        {
+                            var desc = docs?.GetTypeParameterDescription(tp.Name) ?? "_(No Description)_";
+                            writer.WriteLine($"- `{tp.Name}`: {desc}");
+                        }
+                        writer.WriteLine();
+                    }
+
+                    if (docs.HasParameters)
+                    {
+                        writer.WriteHeader(3, "Parameters");
+                        foreach (var p in method.GetParameters())
+                        {
+                            var desc = docs?.GetParameterDescription(p.Name) ?? "_(No Description)_";
+                            writer.WriteLine($"- `{p.Name}`: {desc}");
+                        }
+                        writer.WriteLine();
+                    }
 
                     if (docs.Returns != null)
                     {
@@ -89,8 +100,8 @@ namespace Docpal.Pages
                         writer.WriteLine(docs.Remarks);
                     }
 
-				}
-			}
-		}
-	}
+                }
+            }
+        }
+    }
 }

--- a/Docpal/Program.cs
+++ b/Docpal/Program.cs
@@ -12,10 +12,15 @@ namespace Docpal
 			var paths = Args.GetPaths();
 			if (paths.Length == 0 || Args.Help)
 			{
-				Console.WriteLine($"Usage: {AppDomain.CurrentDomain.FriendlyName} [OPTIONS]... <path_to_dll> -out <output_folder>");
+				Console.WriteLine($"Usage: {AppDomain.CurrentDomain.FriendlyName} [OPTIONS]... <dll_pathfilename>");
                 Console.WriteLine();
                 Console.WriteLine($"Options:");
+                Console.WriteLine($"  -out <path>    Specifies the path where the docs will be saved.");
+                Console.WriteLine($"  -xml <path>    Specifies a custom XML documentation path.");
+                Console.WriteLine($"  --slim         Specifies that the docs will be combined into a single .md file.");
+                Console.WriteLine($"  --noxml        Don't use XML.");
                 Console.WriteLine($"  --mgtable      methods groups in type page will reported in a table with summary foreach method in the group");
+                Console.WriteLine($"  --mgspace      space vertically each method when reported in groups");
                 Console.WriteLine($"  --proptable    properties in type page will reported in a table with summary foreach");
 				return;
 			}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ docpal Rant.dll -out ./docs
 
 Boom, you have your docs. *It's that easy!*
 
+## Install
+
+- Requirements: [Download NET Core SDK](https://dotnet.microsoft.com/download)
+- Install the tool:
+
+```sh
+dotnet tool install -g netcore-docpal
+```
+
+- To update if already installed:
+
+```sh
+dotnet tool update -g netcore-docpal
+```
+
 ## What Docpal offers
 
 ### Get started in minutes instead of hours
@@ -48,13 +63,32 @@ Docpal can be run from a terminal or integrated into your build process to run a
 
 Here are the options it can currently use:
 
-|Option|Description|
-|------|-----------|
-|`-out [path]`|Specifies the path where the docs will be saved.|
-|`-xml [path]`|Specifies a custom XML documentation path.|
-|`--slim`|Specifies that the docs will be combined into a single .md file.|
-|`--noxml`|Don't use XML.|
+```
+Usage: Docpal [OPTIONS]... <dll_pathfilename>
 
-## Compiling
+Options:
+  -out <path>    Specifies the path where the docs will be saved.
+  -xml <path>    Specifies a custom XML documentation path.
+  --slim         Specifies that the docs will be combined into a single .md file.
+  --noxml        Don't use XML.
+  --mgtable      methods groups in type page will reported in a table with summary foreach method in the group
+  --proptable    properties in type page will reported in a table with summary foreach
+```
 
-Docpal is written in C# 7 and requires Visual Studio 2017 to compile.
+### Include netcore assemblies
+
+To produce documentation from a netcore library you may need to include referenced dlls while building it:
+
+```sh
+dotnet build /p:CopyLocalLockFileAssemblies=true
+```
+
+## Compiling and running
+
+Docpal is written in C# 7 and requires Visual Studio 2017 or Visual Studio Code with dotnet core to compile.
+
+```sh
+cd Docpal
+dotnet build -c Release
+dotnet Docpal/bin/Release/netcoreapp2.2/Docpal.dll
+```

--- a/README.md
+++ b/README.md
@@ -24,13 +24,13 @@ Boom, you have your docs. *It's that easy!*
 - Install the tool:
 
 ```sh
-dotnet tool install -g netcore-docpal
+dotnet tool install -g docpal
 ```
 
 - To update if already installed:
 
 ```sh
-dotnet tool update -g netcore-docpal
+dotnet tool update -g docpal
 ```
 
 ## What Docpal offers


### PR DESCRIPTION
- tune README.md with info about compiling, install, running the tool
- added mgspace option to create space between methods ( [example](https://github.com/devel0/netcore-sci/blob/04639b1743c036afec78c290e34b1ad7a21acde7/doc/api/SciExt/Vector3DCoords.md#vector3dcoordslwpolyline) )