### PR TITLE
csproj instruction to build nuget package as installable tool

### DIFF
--- a/Docpal/Docpal.csproj
+++ b/Docpal/Docpal.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>netcoreapp2.2</TargetFramework>
@@ -8,6 +8,8 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageId>Docpal</PackageId>
         <PackageVersion>0.0.1</PackageVersion>
+        <PackAsTool>true</PackAsTool>
+        <ToolCommandName>docpal</ToolCommandName>
         <Title>Docpal</Title>
         <Description></Description>
         <Authors>Nicholas Fleck</Authors>


### PR DESCRIPTION
added

```xml
        <PackAsTool>true</PackAsTool>
        <ToolCommandName>docpal</ToolCommandName>
```

in csproj to instruct nuget to create installable tool package using `dotnet tool install -g docpal`

To publish I used a script like the [this](https://github.com/SearchAThing-forks/Docpal/blob/d910724b2022b39bbeec11643055c64678677d14/publish.sh) that suppose you'll run from win10 linux subsystem bash shell with nuget api key in a plain text (600 mode) file in a `~/security/nuget-api.key`

```sh
#!/bin/bash

exdir=$(dirname `readlink -f "$0"`)

cd "$exdir"/Docpal
rm -fr bin
dotnet pack -c Release
dotnet nuget push bin/Release/*.nupkg -k $(cat ~/security/nuget-api.key) -s https://api.nuget.org/v3/index.json

cd "$exdir"
```

Package I published is named `netcore-docpal` while `docpal` not yet used so there should'n exists any conflicts. But the way I'll unlist `netcore-docpal` package from the search result when your get published.