### PR TITLE
Fixcrash

### DIFF
--- a/Docpal/Args.cs
+++ b/Docpal/Args.cs
@@ -41,7 +41,8 @@ namespace Docpal
         public static readonly bool Help;
 
         public static readonly bool MethodGroupsTable;
-        public static readonly bool PropertiesTable;
+        public static readonly bool MethodGroupsSpacing;
+        public static readonly bool PropertiesTable;        
 
         static Args()
         {
@@ -74,6 +75,7 @@ namespace Docpal
                 {
                     var flag = args[i].TrimStart('-');
                     if (flag == "mgtable") MethodGroupsTable = true;
+                    else if (flag == "mgspace") MethodGroupsSpacing = true;
                     else if (flag == "proptable") PropertiesTable = true;
                     Flags.Add(flag);
                 }

--- a/Docpal/DocUtilities.cs
+++ b/Docpal/DocUtilities.cs
@@ -565,7 +565,7 @@ namespace Docpal
             // e.g. Dictionary<string, int>
             else if (bareType.IsGenericType)
             {
-                if (includeNamespace)
+                if (includeNamespace && !string.IsNullOrEmpty(bareType.Namespace))
                 {
                     sb.Append($"{bareType.Namespace}.");
                 }
@@ -588,7 +588,7 @@ namespace Docpal
             // e.g. System.String
             else
             {
-                if (includeNamespace) sb.Append($"{bareType.Namespace}.");
+                if (includeNamespace && !string.IsNullOrEmpty(bareType.Namespace)) sb.Append($"{bareType.Namespace}.");
                 sb.Append(bareName);
             }
 

--- a/Docpal/DocUtilities.cs
+++ b/Docpal/DocUtilities.cs
@@ -176,7 +176,7 @@ namespace Docpal
 
         public static string GetURLTitle(Type type)
         {
-            if (type.IsGenericType)
+            if (type.IsGenericType && type.Name.Contains("`"))
             {
                 return $"{type.Name.Substring(0, type.Name.IndexOf("`"))}-{type.GetGenericArguments().Length}";
             }
@@ -563,8 +563,8 @@ namespace Docpal
                 sb.Append(primitiveName);
             }
             // e.g. Dictionary<string, int>
-            else if (bareType.IsGenericType)
-            {
+            else if (bareType.IsGenericType && bareType.Name.Contains("`"))
+            {                
                 if (includeNamespace && !string.IsNullOrEmpty(bareType.Namespace))
                 {
                     sb.Append($"{bareType.Namespace}.");

--- a/Docpal/Docpal.csproj
+++ b/Docpal/Docpal.csproj
@@ -7,7 +7,7 @@
     <PropertyGroup>        
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageId>netcore-docpal</PackageId>
-        <PackageVersion>0.0.7</PackageVersion>
+        <PackageVersion>0.0.8</PackageVersion>
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>docpal</ToolCommandName>
         <Title>Docpal</Title>

--- a/Docpal/Docpal.csproj
+++ b/Docpal/Docpal.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>netcoreapp2.2</TargetFramework>
@@ -6,15 +6,15 @@
     </PropertyGroup>
     <PropertyGroup>        
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
-        <PackageId>Docpal</PackageId>
-        <PackageVersion>0.0.1</PackageVersion>
+        <PackageId>netcore-docpal</PackageId>
+        <PackageVersion>0.0.6</PackageVersion>
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>docpal</ToolCommandName>
         <Title>Docpal</Title>
-        <Description></Description>
+        <Description>NET core porting of Docpal utility of Nicholas Fleck</Description>
         <Authors>Nicholas Fleck</Authors>
-        <PackageTags>autogen api markdown csharp</PackageTags>
-        <PackageProjectUrl>https://github.com/TheBerkin/Docpal</PackageProjectUrl>
+        <PackageTags>netcore autogen api markdown csharp</PackageTags>
+        <PackageProjectUrl>https://github.com/SearchAThing-forks/Docpal/tree/dev#docpal</PackageProjectUrl>
         <PackageLicenseExpression>MIT</PackageLicenseExpression>
     </PropertyGroup>
     <ItemGroup>

--- a/Docpal/Docpal.csproj
+++ b/Docpal/Docpal.csproj
@@ -7,7 +7,7 @@
     <PropertyGroup>        
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageId>netcore-docpal</PackageId>
-        <PackageVersion>0.0.6</PackageVersion>
+        <PackageVersion>0.0.7</PackageVersion>
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>docpal</ToolCommandName>
         <Title>Docpal</Title>

--- a/Docpal/Docpal.csproj
+++ b/Docpal/Docpal.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
         <TargetFramework>netcoreapp2.2</TargetFramework>
@@ -8,6 +8,8 @@
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageId>Docpal</PackageId>
         <PackageVersion>0.0.1</PackageVersion>
+        <PackAsTool>true</PackAsTool>
+        <ToolCommandName>docpal</ToolCommandName>
         <Title>Docpal</Title>
         <Description></Description>
         <Authors>Nicholas Fleck</Authors>

--- a/Docpal/Docpal.csproj
+++ b/Docpal/Docpal.csproj
@@ -1,13 +1,13 @@
 <Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>netcoreapp2.2</TargetFramework>
+        <TargetFrameworks>netcoreapp2.2;netcoreapp3.0</TargetFrameworks>
         <LangVersion>7.3</LangVersion>
     </PropertyGroup>
     <PropertyGroup>        
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
         <PackageId>netcore-docpal</PackageId>
-        <PackageVersion>0.0.8</PackageVersion>
+        <PackageVersion>0.0.9</PackageVersion>
         <PackAsTool>true</PackAsTool>
         <ToolCommandName>docpal</ToolCommandName>
         <Title>Docpal</Title>

--- a/Docpal/DocpalPages.cs
+++ b/Docpal/DocpalPages.cs
@@ -30,113 +30,115 @@ using System.Threading.Tasks;
 
 namespace Docpal
 {
-	class DocpalPages : DocpalGenerator
-	{
-		public DocpalPages(ProjectXmlDocs docs, Assembly asm) : base(docs, asm)
-		{
-		}
+    class DocpalPages : DocpalGenerator
+    {
+        public DocpalPages(ProjectXmlDocs docs, Assembly asm) : base(docs, asm)
+        {
+        }
 
-		public override void BuildDocs(string outputPath)
-		{
-			var pages = new PageTree("docs");
-			var PageTrees = new List<PageTree>();
+        public override void BuildDocs(string outputPath)
+        {
+            var pages = new PageTree("docs");
+            var PageTrees = new List<PageTree>();
 
-			foreach (var type in Library.GetExportedTypes())
-			{
-				var typePath = $"{type.Namespace.Replace('.', '/')}/{DocUtilities.GetURLTitle(type)}";
-				var typeData = Docs[ID.GetIDString(type)];
+            foreach (var type in Library.GetExportedTypes())
+            {
+                var typePath = $"{DocUtilities.GetURLTitle(type)}";
+                if (type.Namespace != null)
+                    typePath = $"{type.Namespace.Replace('.', '/')}/{typePath}";
+                var typeData = Docs[ID.GetIDString(type)];
 
-				pages[typePath] = new TypePage(type, typeData, Docs);
-				PageTrees.Add(pages.GetNode(typePath));
+                pages[typePath] = new TypePage(type, typeData, Docs);
+                PageTrees.Add(pages.GetNode(typePath));
 
-				// Constructors
-				var ctors = type.GetConstructors();
-				if (ctors.Length > 0)
-				{
+                // Constructors
+                var ctors = type.GetConstructors();
+                if (ctors.Length > 0)
+                {
                     // Path to ctors group
-					var ctorsGroupPath = $"{typePath}/ctors";
+                    var ctorsGroupPath = $"{typePath}/ctors";
 
                     var ctorsData = new Dictionary<ConstructorInfo, MemberXmlDocs>();
                     foreach (var ctor in ctors)
                     {
                         var ctorData = Docs[ID.GetIDString(ctor)];
                         ctorsData.Add(ctor, ctorData);
-                    } 
+                    }
 
-					pages[ctorsGroupPath] = new ConstructorsPage(type, ctors, ctorsData);
-					PageTrees.Add(pages.GetNode(ctorsGroupPath));                    
-				}
+                    pages[ctorsGroupPath] = new ConstructorsPage(type, ctors, ctorsData);
+                    PageTrees.Add(pages.GetNode(ctorsGroupPath));
+                }
 
-				// Method groups
-				foreach (var methodGroup in type.GetMethods()
-					.Where(m => !m.Name.StartsWith("get_") && !m.Name.StartsWith("set_"))
-					.GroupBy(m => m.Name))
-				{
-					// Path to method group
-					var methodGroupPath = $"{typePath}/{methodGroup.Key}";
+                // Method groups
+                foreach (var methodGroup in type.GetMethods()
+                    .Where(m => !m.Name.StartsWith("get_") && !m.Name.StartsWith("set_"))
+                    .GroupBy(m => m.Name))
+                {
+                    // Path to method group
+                    var methodGroupPath = $"{typePath}/{methodGroup.Key}";
 
-					// Map of reflected methods and documentation
-					var methods = new Dictionary<MethodInfo, MemberXmlDocs>();
+                    // Map of reflected methods and documentation
+                    var methods = new Dictionary<MethodInfo, MemberXmlDocs>();
 
-					foreach (var method in methodGroup)
-					{
-						var methodData = Docs[ID.GetIDString(method)];
-						methods[method] = methodData;
-					}
+                    foreach (var method in methodGroup)
+                    {
+                        var methodData = Docs[ID.GetIDString(method)];
+                        methods[method] = methodData;
+                    }
 
-					pages[methodGroupPath] = new MethodGroupPage(type, methodGroup.Key, methods);
-					PageTrees.Add(pages.GetNode(methodGroupPath));
-				}
+                    pages[methodGroupPath] = new MethodGroupPage(type, methodGroup.Key, methods);
+                    PageTrees.Add(pages.GetNode(methodGroupPath));
+                }
 
-				// Fields
-				foreach (var field in type.GetFields().Where(f => (f.IsPublic || !f.IsPrivate) && (!f.DeclaringType.IsEnum || !f.IsSpecialName)))
-				{
-					var fieldPath = Path.Combine(typePath, field.Name).Replace('\\', '/');
-					var fieldData = Docs[ID.GetIDString(field)];
-					pages[fieldPath] = new FieldPage(field, fieldData);
-					PageTrees.Add(pages.GetNode(fieldPath));
-				}
+                // Fields
+                foreach (var field in type.GetFields().Where(f => (f.IsPublic || !f.IsPrivate) && (!f.DeclaringType.IsEnum || !f.IsSpecialName)))
+                {
+                    var fieldPath = Path.Combine(typePath, field.Name).Replace('\\', '/');
+                    var fieldData = Docs[ID.GetIDString(field)];
+                    pages[fieldPath] = new FieldPage(field, fieldData);
+                    PageTrees.Add(pages.GetNode(fieldPath));
+                }
 
-				// Properties and Indexers
-				int numIndexers = 0;
-				foreach (var property in type.GetProperties())
-				{
-					var propData = Docs[ID.GetIDString(property)];
+                // Properties and Indexers
+                int numIndexers = 0;
+                foreach (var property in type.GetProperties())
+                {
+                    var propData = Docs[ID.GetIDString(property)];
 
-					string propPath;
-					if (property.GetIndexParameters().Length > 0)
-					{
-						propPath = $"{typePath}/this/{++numIndexers}";
-					}
-					else
-					{
-						propPath = $"{typePath}/{property.Name}";
-					}
+                    string propPath;
+                    if (property.GetIndexParameters().Length > 0)
+                    {
+                        propPath = $"{typePath}/this/{++numIndexers}";
+                    }
+                    else
+                    {
+                        propPath = $"{typePath}/{property.Name}";
+                    }
 
-					pages[propPath] = new PropertyPage(property, propData);
-					PageTrees.Add(pages.GetNode(propPath));
-				}
-			}
+                    pages[propPath] = new PropertyPage(property, propData);
+                    PageTrees.Add(pages.GetNode(propPath));
+                }
+            }
 
-			// Create a task for each document that needs to be exported, run them all at once
-			var exportTasks = new Task[PageTrees.Count];
-			for (int i = 0; i < PageTrees.Count; i++)
-			{
-				var node = PageTrees[i];
-				exportTasks[i] = Task.Run(() =>
-				{
-					var documentDir = Directory.GetParent($"{outputPath}/{node.Path}").FullName;
-					var documentPath = $"{outputPath}/{node.Path}.md";
-					Directory.CreateDirectory(documentDir);
-					using (var writer = new MarkdownWriter(documentPath))
-					{
-						node.Page.Render(node, writer);
-					}
-				});
-			}
+            // Create a task for each document that needs to be exported, run them all at once
+            var exportTasks = new Task[PageTrees.Count];
+            for (int i = 0; i < PageTrees.Count; i++)
+            {
+                var node = PageTrees[i];
+                exportTasks[i] = Task.Run(() =>
+                {
+                    var documentDir = Directory.GetParent($"{outputPath}/{node.Path}").FullName;
+                    var documentPath = $"{outputPath}/{node.Path}.md";
+                    Directory.CreateDirectory(documentDir);
+                    using (var writer = new MarkdownWriter(documentPath))
+                    {
+                        node.Page.Render(node, writer);
+                    }
+                });
+            }
 
-			// Wait for all export tasks to finish
-			Task.WaitAll(exportTasks);
-		}
-	}
+            // Wait for all export tasks to finish
+            Task.WaitAll(exportTasks);
+        }
+    }
 }

--- a/Docpal/Pages/ConstructorsPage.cs
+++ b/Docpal/Pages/ConstructorsPage.cs
@@ -47,7 +47,7 @@ namespace Docpal.Pages
             writer.WriteHeader(1, Title);
             foreach (var (ctor, idx) in _ctors.Select((ctor, idx) => (ctor, idx)))
             {
-                if (idx > 0)
+                if (Args.MethodGroupsSpacing && idx > 0)
                 {
                     writer.WriteLine();                    
                     writer.WriteLine("<p>&nbsp;</p>");

--- a/Docpal/Pages/MethodGroupPage.cs
+++ b/Docpal/Pages/MethodGroupPage.cs
@@ -28,54 +28,65 @@ using System.Reflection;
 
 namespace Docpal.Pages
 {
-	public class MethodGroupPage : Page
-	{
-		private readonly Type _type;
-		private readonly Dictionary<MethodInfo, MemberXmlDocs> _methodData;
+    public class MethodGroupPage : Page
+    {
+        private readonly Type _type;
+        private readonly Dictionary<MethodInfo, MemberXmlDocs> _methodData;
 
-		public MethodGroupPage(Type type, string name, Dictionary<MethodInfo, MemberXmlDocs> methodData) : base(null)
-		{
-			_type = type;
-			_methodData = methodData;
-			Title = $"{DocUtilities.GetDisplayTitle(type)}.{DocUtilities.GetIdentifier(name)} method";
-		}
+        public MethodGroupPage(Type type, string name, Dictionary<MethodInfo, MemberXmlDocs> methodData) : base(null)
+        {
+            _type = type;
+            _methodData = methodData;
+            Title = $"{DocUtilities.GetDisplayTitle(type)}.{DocUtilities.GetIdentifier(name)} method";
+        }
 
-		public override void Render(PageTree parent, MarkdownWriter writer)
-		{
-			writer.WriteHeader(1, Title);
-			foreach (var data in _methodData.OrderBy(m => m.Key.GetParameters().Length))
-			{
-				var method = data.Key;
-				var docs = data.Value;
+        public override void Render(PageTree parent, MarkdownWriter writer)
+        {
+            writer.WriteHeader(1, Title);
+            foreach (var (data, idx) in _methodData                
+                .OrderBy(m => m.Key.GetParameters().Length)
+                .Select((data, idx) => (data, idx)))
+            {
+                var method = data.Key;
+                var docs = data.Value;
 
-				writer.WriteHeader(2, DocUtilities.GetMethodSignature(method, false, false));
-				writer.WriteParagraph(docs?.Summary);
-				writer.WriteHeader(3, "Signature");
-				writer.WriteCodeBlock("csharp", DocUtilities.GetMethodSignature(method, true, true));
+                if (Args.MethodGroupsSpacing && idx > 0)
+                {
+                    writer.WriteLine();
+                    writer.WriteLine("<p>&nbsp;</p>");
+                    writer.WriteLine("<p>&nbsp;</p>");
+                    writer.WriteLine("<hr/>");
+                    writer.WriteLine();
+                }
 
-				if (docs != null)
-				{
-					if (docs.HasTypeParameters)
-					{
-						writer.WriteHeader(3, "Type Parameters");
-						foreach (var tp in method.GetGenericArguments())
-						{
-							var desc = docs?.GetTypeParameterDescription(tp.Name) ?? "_(No Description)_";
-							writer.WriteLine($"- `{tp.Name}`: {desc}");
-						}
-						writer.WriteLine();
-					}
+                writer.WriteHeader(2, DocUtilities.GetMethodSignature(method, false, false));
+                writer.WriteParagraph(docs?.Summary);
+                writer.WriteHeader(3, "Signature");
+                writer.WriteCodeBlock("csharp", DocUtilities.GetMethodSignature(method, true, true));
 
-					if (docs.HasParameters)
-					{
-						writer.WriteHeader(3, "Parameters");
-						foreach (var p in method.GetParameters())
-						{
-							var desc = docs?.GetParameterDescription(p.Name) ?? "_(No Description)_";
-							writer.WriteLine($"- `{p.Name}`: {desc}");
-						}
-						writer.WriteLine();
-					}
+                if (docs != null)
+                {
+                    if (docs.HasTypeParameters)
+                    {
+                        writer.WriteHeader(3, "Type Parameters");
+                        foreach (var tp in method.GetGenericArguments())
+                        {
+                            var desc = docs?.GetTypeParameterDescription(tp.Name) ?? "_(No Description)_";
+                            writer.WriteLine($"- `{tp.Name}`: {desc}");
+                        }
+                        writer.WriteLine();
+                    }
+
+                    if (docs.HasParameters)
+                    {
+                        writer.WriteHeader(3, "Parameters");
+                        foreach (var p in method.GetParameters())
+                        {
+                            var desc = docs?.GetParameterDescription(p.Name) ?? "_(No Description)_";
+                            writer.WriteLine($"- `{p.Name}`: {desc}");
+                        }
+                        writer.WriteLine();
+                    }
 
                     if (docs.Returns != null)
                     {
@@ -89,8 +100,8 @@ namespace Docpal.Pages
                         writer.WriteLine(docs.Remarks);
                     }
 
-				}
-			}
-		}
-	}
+                }
+            }
+        }
+    }
 }

--- a/Docpal/Program.cs
+++ b/Docpal/Program.cs
@@ -12,10 +12,15 @@ namespace Docpal
 			var paths = Args.GetPaths();
 			if (paths.Length == 0 || Args.Help)
 			{
-				Console.WriteLine($"Usage: {AppDomain.CurrentDomain.FriendlyName} [OPTIONS]... <path_to_dll> -out <output_folder>");
+				Console.WriteLine($"Usage: {AppDomain.CurrentDomain.FriendlyName} [OPTIONS]... <dll_pathfilename>");
                 Console.WriteLine();
                 Console.WriteLine($"Options:");
+                Console.WriteLine($"  -out <path>    Specifies the path where the docs will be saved.");
+                Console.WriteLine($"  -xml <path>    Specifies a custom XML documentation path.");
+                Console.WriteLine($"  --slim         Specifies that the docs will be combined into a single .md file.");
+                Console.WriteLine($"  --noxml        Don't use XML.");
                 Console.WriteLine($"  --mgtable      methods groups in type page will reported in a table with summary foreach method in the group");
+                Console.WriteLine($"  --mgspace      space vertically each method when reported in groups");
                 Console.WriteLine($"  --proptable    properties in type page will reported in a table with summary foreach");
 				return;
 			}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,21 @@ docpal Rant.dll -out ./docs
 
 Boom, you have your docs. *It's that easy!*
 
+## Install
+
+- Requirements: [Download NET Core SDK](https://dotnet.microsoft.com/download)
+- Install the tool:
+
+```sh
+dotnet tool install -g docpal
+```
+
+- To update if already installed:
+
+```sh
+dotnet tool update -g docpal
+```
+
 ## What Docpal offers
 
 ### Get started in minutes instead of hours
@@ -48,13 +63,32 @@ Docpal can be run from a terminal or integrated into your build process to run a
 
 Here are the options it can currently use:
 
-|Option|Description|
-|------|-----------|
-|`-out [path]`|Specifies the path where the docs will be saved.|
-|`-xml [path]`|Specifies a custom XML documentation path.|
-|`--slim`|Specifies that the docs will be combined into a single .md file.|
-|`--noxml`|Don't use XML.|
+```
+Usage: Docpal [OPTIONS]... <dll_pathfilename>
 
-## Compiling
+Options:
+  -out <path>    Specifies the path where the docs will be saved.
+  -xml <path>    Specifies a custom XML documentation path.
+  --slim         Specifies that the docs will be combined into a single .md file.
+  --noxml        Don't use XML.
+  --mgtable      methods groups in type page will reported in a table with summary foreach method in the group
+  --proptable    properties in type page will reported in a table with summary foreach
+```
 
-Docpal is written in C# 7 and requires Visual Studio 2017 to compile.
+### Include netcore assemblies
+
+To produce documentation from a netcore library you may need to include referenced dlls while building it:
+
+```sh
+dotnet build /p:CopyLocalLockFileAssemblies=true
+```
+
+## Compiling and running
+
+Docpal is written in C# 7 and requires Visual Studio 2017 or Visual Studio Code with dotnet core to compile.
+
+```sh
+cd Docpal
+dotnet build -c Release
+dotnet Docpal/bin/Release/netcoreapp2.2/Docpal.dll
+```

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Docpal
 [![Build status](https://ci.appveyor.com/api/projects/status/dlvs655kyryk0doy?svg=true)](https://ci.appveyor.com/project/TheBerkin/docpal)
+[![NuGet Badge](https://buildstats.info/nuget/netcore-docpal)](https://www.nuget.org/packages/netcore-docpal/)
 
 **Are overcomplicated documentation tools making you headbang a brick wall?**
 
@@ -24,13 +25,13 @@ Boom, you have your docs. *It's that easy!*
 - Install the tool:
 
 ```sh
-dotnet tool install -g docpal
+dotnet tool install -g netcore-docpal
 ```
 
 - To update if already installed:
 
 ```sh
-dotnet tool update -g docpal
+dotnet tool update -g netcore-docpal
 ```
 
 ## What Docpal offers

--- a/publish.sh
+++ b/publish.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+exdir=$(dirname `readlink -f "$0"`)
+
+cd "$exdir"/Docpal
+rm -fr bin
+dotnet pack -c Release
+dotnet nuget push bin/Release/*.nupkg -k $(cat ~/security/nuget-api.key) -s https://api.nuget.org/v3/index.json
+
+cd "$exdir"


### PR DESCRIPTION
fix crash when generating doc for this project (https://github.com/devel0/netcore-ef-util) for class MapMismatchException that is a nested class inside another with template;

the fix is more like a workaround I've just added an AND that ensure type name contains backquote elsewhere it proceed with normal name extraction.